### PR TITLE
Checking in changes prior to tagging of version 0.96.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension Log-GELF-Util
 
 {{$NEXT}}
 
+0.96 2016-03-01T12:49:34Z
+
+    - added ability to specify message id when chunking
+
 0.95 2016-02-26T00:26:50Z
 
     - improve documentaion

--- a/META.json
+++ b/META.json
@@ -71,9 +71,10 @@
          "web" : "https://github.com/strategicdata/log-gelf-util"
       }
    },
-   "version" : "0.95",
+   "version" : "0.96",
    "x_contributors" : [
-      "Adam Clarke <adam.clarke@strategicdata.com.au>"
+      "Adam Clarke <adam.clarke@strategicdata.com.au>",
+      "Adam Clarke <adam@clarke.id.au>"
    ],
    "x_serialization_backend" : "JSON::PP version 2.27300"
 }

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ see ["parse\_size"](#parse_size). Defaults to `wan`. A zero chunk size means no 
 will be applied.
 
 The optional third parameter is the message id used to identify associated
-chunks. This must be 8 bytes. It defauts to 8 bytes of randomness generated
+chunks. This must be 8 bytes. It defaults to 8 bytes of randomness generated
 by [Math::Random::MT](https://metacpan.org/pod/Math::Random::MT).
 
 If the message size is greater than the maximum size then an array of

--- a/lib/Log/GELF/Util.pm
+++ b/lib/Log/GELF/Util.pm
@@ -20,7 +20,7 @@ our (
     $LEVEL_NAME_REGEX,
 );
 
-$VERSION = "0.95";
+$VERSION = "0.96";
 
 use Params::Validate qw(
     validate
@@ -579,7 +579,7 @@ see L</parse_size>. Defaults to C<wan>. A zero chunk size means no chunking
 will be applied.
 
 The optional third parameter is the message id used to identify associated
-chunks. This must be 8 bytes. It defauts to 8 bytes of randomness generated
+chunks. This must be 8 bytes. It defaults to 8 bytes of randomness generated
 by L<Math::Random::MT>.
 
 If the message size is greater than the maximum size then an array of


### PR DESCRIPTION
Changelog diff is:

diff --git a/Changes b/Changes
index d7b6e92..f9bd361 100644
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension Log-GELF-Util

 {{$NEXT}}

+0.96 2016-03-01T12:49:34Z
+
- - added ability to specify message id when chunking
    +
    0.95 2016-02-26T00:26:50Z
  - improve documentaion
